### PR TITLE
Time and cost adjustments for acid wells.

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -875,13 +875,13 @@ TUNNEL
 			to_chat(X, "<span class='xenoannounce'>[src] is already being filled!</span>")
 			return
 		ccharging = TRUE
-		if(!do_after(X, 10 SECONDS, FALSE, src, BUSY_ICON_BUILD))
+		if(!do_after(X, 2 SECONDS, FALSE, src, BUSY_ICON_BUILD))
 			ccharging = FALSE
 			return
-		if(X.plasma_stored < 200)
+		if(X.plasma_stored < 100)
 			ccharging = FALSE
 			return
-		X.plasma_stored -= 200
+		X.plasma_stored -= 100
 		charges++
 		ccharging = FALSE
 		update_icon()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Where as before it would take a whopping 10 seconds to fill an acid well with a single charge, now it only takes 2 seconds per charge. This seems much more reasonable, given how often acid wells are used in hive constructions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier for xenos to spruce up the hive and maintains their sanity at the same time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced the cost and time it takes to fill acid wells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
